### PR TITLE
releases: enhancement to clean release page

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -25,7 +25,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - run: |
-          pip install pygithub sphinx-rtd-theme exhale sphinx_pdj_theme sphinx_simplepdf
+          pip install pygithub sphinx-rtd-theme exhale sphinx_pdj_theme rstcloth
           sudo apt-get -y install meson python3-sphinx ninja-build
         shell: bash
       - uses: actions/checkout@v4

--- a/meson.build
+++ b/meson.build
@@ -27,9 +27,9 @@ sphinx = find_program('sphinx-build')
 py3 = pymod.find_installation(
     'python3',
     modules: [
-        'exhale',
         'sphinx_pdj_theme',
-        'sphinx_simplepdf',
+        'rstcloth',
+        'github',
     ]
     )
 

--- a/support/tools/gen_releases.py
+++ b/support/tools/gen_releases.py
@@ -62,8 +62,6 @@ with open(target, 'w') as indexfile:
                 widths=['30', '65'],
                 width='100%'
             )
-            #doc.li(doc.inline_link(asset.name, asset.browser_download_url))
-            #indexfile.write("  * `" + asset.name + " <" + asset.browser_download_url + ">`_\n")
             doc.newline()
         doc.newline()
 

--- a/support/tools/gen_releases.py
+++ b/support/tools/gen_releases.py
@@ -57,7 +57,7 @@ with open(target, 'w') as indexfile:
 
                 data=[
                     ['size', str(asset.size / (1000)) + 'KB'],
-                    ['architecture', asset.name.split('_')[0].split('-')[-1] ],
+                    ['architecture', asset.name.split('_')[0][12:] ],
                 ],
                 widths=['30', '65'],
                 width='100%'


### PR DESCRIPTION
using rstcloth for ReST generation instead of bare.
Generating clean rendering for releases, including releases changelogs:

![Screenshot from 2025-05-21 11-10-28](https://github.com/user-attachments/assets/fb3f6d78-cdc5-42ef-81c4-2b1a60ccaae2)
